### PR TITLE
Fix/validation

### DIFF
--- a/src/constants/Contacts/contactsSchema.ts
+++ b/src/constants/Contacts/contactsSchema.ts
@@ -4,7 +4,7 @@ export const contactsSchema = yup.object().shape({
 	name: yup
 		.string()
 		.required('Введите имя')
-		.matches(/^[а-яА-Яa-zA-Z][а-яА-Яa-zA-Z\s]{2,30}$/, 'Неверный формат'),
+		.matches(/^[а-яА-Яa-zA-Z][а-яА-Яa-zA-Z\s]{1,50}$/, 'Неверный формат'),
 	tel: yup
 		.string()
 		.required('Введите номер телефона')
@@ -13,7 +13,7 @@ export const contactsSchema = yup.object().shape({
 		.string()
 		.required('Введите E-mail')
 		.matches(
-			/^([a-zA-Z0-9][a-zA-Z0-9_.-]{1,62}[a-zA-Z0-9])@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z0-9][a-zA-Z\-0-9]{1,64}[a-zA-Z0-9]\.){1,3}[a-zA-Z]{2,64}))$/,
+			/^([a-zA-Z0-9][a-zA-Z0-9_.-]{1,62}[a-zA-Z0-9])@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z0-9][a-zA-Z\-0-9]{1,56}[a-zA-Z0-9]\.){1,3}[a-zA-Z]{2,64}))$/,
 			'Неверный формат E-mail'
 		),
 	message: yup.string().notRequired(),

--- a/src/constants/Promo/promoSchema.ts
+++ b/src/constants/Promo/promoSchema.ts
@@ -4,7 +4,7 @@ export const promoSchema = yup.object().shape({
 	name: yup
 		.string()
 		.required('Введите имя')
-		.matches(/^[а-яА-Яa-zA-Z\s]{2,30}$/, 'Неверный формат'),
+		.matches(/^[а-яА-Яa-zA-Z][а-яА-Яa-zA-Z\s]{1,50}$/, 'Неверный формат'),
 	tel: yup
 		.string()
 		.required('Введите номер телефона')


### PR DESCRIPTION
Исправлены следующие недочеты в валидации:
1. FR-5
[При вводе нескольких пробелов в поле "Имя" кнопка "отправить" кликабельна в форме "обратной связи" на главной странице сайта](https://katyatest.youtrack.cloud/issue/FR-5/Pri-vvode-neskolkih-probelov-v-pole-Imya-knopka-otpravit-klikabelna-v-forme-obratnoj-svyazi-na-glavnoj-stranice-sajta)
2. FR-32
[Отсутствие валидации при вводе больше 63 символов в доменной части емайла в блоке "контакты"](https://katyatest.youtrack.cloud/issue/FR-32/Otsutstvie-validacii-pri-vvode-bolshe-63-simvolov-v-domennoj-chasti-emajla-v-bloke-kontakty)

По поводу FR-33
[Отсутствует валидация при вводе пробелов в поле "Имя" в блоке контакты](https://katyatest.youtrack.cloud/issue/FR-33/Otsutstvuet-validaciya-pri-vvode-probelov-v-pole-Imya-v-bloke-kontakty) было ранее обговорено, что вариант с пробелами допустим, поэтому ничего не меняла в коде

Некоторые баги не были исправлены, так как мы пока не можем прийти к единому решению, возможно, нужно будет подключать другие библиотеки для работы с номером, поэтому пока решили залить то, что есть, а над этими вопросами подумать после:
1. FR-4
[Возможность ввода невалидного номера в поле "телефон" в форме "обратной связи" на главной странице сайта](https://katyatest.youtrack.cloud/issue/FR-4/Vozmozhnost-vvoda-nevalidnogo-nomera-v-pole-telefon-v-forme-obratnoj-svyazi-na-glavnoj-stranice-sajta)
2. FR-31
[Отсутствие валидации при вводе в локальной части емайла 2 и более точек подряд](https://katyatest.youtrack.cloud/issue/FR-31/Otsutstvie-validacii-pri-vvode-v-lokalnoj-chasti-emajla-2-i-bolee-tochek-podryad)

