### PR TITLE
Fix/about-us-top-padding

### DIFF
--- a/src/components/AboutUs/styles.module.scss
+++ b/src/components/AboutUs/styles.module.scss
@@ -136,6 +136,7 @@
 
 @media screen and (max-width: 833px) {
   .about-us {
+    padding-top: 80px;
     max-width: var(--width-768-280);
     &__h2-title {
       font-size: 40px;
@@ -175,7 +176,6 @@
 
 @media screen and (max-width: 580px) {
   .about-us {
-    padding-top: 80px;
     padding-bottom: 0;
   }
 }


### PR DESCRIPTION
Добавила верхний отступ для блока "О нас" в диапазоне ширины экрана от 833px до 581px

![Screenshot_4](https://github.com/Team-Code-Wizards/frontend/assets/98664770/973922ae-ce08-4fb6-ac39-cfa0e162335d)
