### PR TITLE
Fix: small-fixes

### DIFF
--- a/public/images/icons/ArrowBack.tsx
+++ b/public/images/icons/ArrowBack.tsx
@@ -10,8 +10,8 @@ export default function ArrowBack() {
 			<path
 				d="M4.66667 7.33398L2 10.0007M2 10.0007L4.66667 12.6673M2 10.0007H10.6667C12.5076 10.0007 14 8.50827 14 6.66732C14 4.82637 12.5076 3.33398 10.6667 3.33398H7.33333"
 				stroke="white"
-				stroke-linecap="round"
-				stroke-linejoin="round"
+				strokeLinecap="round"
+				strokeLinejoin="round"
 			/>
 		</svg>
 	);

--- a/src/app/privacy-policy/style.module.scss
+++ b/src/app/privacy-policy/style.module.scss
@@ -37,6 +37,14 @@
 				font-size: 32px;
 				margin-bottom: 6px;
 			}
+
+			@media (max-width: 350px) {
+				font-size: 30px;
+			}
+
+			@media (max-width: 330px) {
+				font-size: 28px;
+			}
 		}
 
 		h3 {


### PR DESCRIPTION
Сделано:
1. Исправлен баг: "Отсутствует правый отступ у заголовка "Политика конфиденциальности" при ширине экрана < 350px.
2. Исправлен баг в svg-иконке ArrowBack.