### PR TITLE
Fix/nav-padding-mobile

### DIFF
--- a/src/components/AdvertisingPromo/styles.module.scss
+++ b/src/components/AdvertisingPromo/styles.module.scss
@@ -259,6 +259,7 @@
       grid-area: 1 / 1 / 2 / 2;
       padding-top: 0;
       margin-bottom: 34px;
+      margin-top: 30px;
 
       &-img {
         width: 100%;

--- a/src/components/Navbar/style.module.scss
+++ b/src/components/Navbar/style.module.scss
@@ -9,7 +9,7 @@
 	border-radius: 10px;
 	padding: 14px 20px;
 	background: rgba(53, 42, 121, 0.4);
-	box-shadow: 0px 4px 46.7px rgba(0, 0, 0, 0.25);
+	box-shadow: 0 4px 46.7px rgba(0, 0, 0, 0.25);
 	-webkit-backdrop-filter: blur(4px);
 	backdrop-filter: blur(20px);
 	justify-content: space-between;
@@ -182,5 +182,9 @@
 	.navbar {
 		gap: calc((100vh - 290px) * 0.21);
 		padding: 28px 28px 9px;
+	}
+
+	.nav-icons {
+		top: 50px;
 	}
 }


### PR DESCRIPTION
Изменила отступ от иконок навигационного меню до изображения в блоке промо согласно макету
P.s. по макету отступ 40px, а не 20px
![Screenshot_1](https://github.com/Team-Code-Wizards/frontend/assets/98664770/f5d9fc7d-a62c-4fca-9f5d-e2c37a35abdf)
